### PR TITLE
Adding the migration controller

### DIFF
--- a/pkg/controller/helpers.go
+++ b/pkg/controller/helpers.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	migrationv1alpha1 "github.com/kubernetes-sigs/kube-storage-version-migrator/pkg/apis/migration/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func hasCondition(m *migrationv1alpha1.StorageVersionMigration, conditionType migrationv1alpha1.MigrationConditionType) bool {
+	return indexOfCondition(m, conditionType) != -1
+}
+
+func indexOfCondition(m *migrationv1alpha1.StorageVersionMigration, conditionType migrationv1alpha1.MigrationConditionType) int {
+	for i, c := range m.Status.Conditions {
+		if c.Type == conditionType && c.Status == corev1.ConditionTrue {
+			return i
+		}
+	}
+	return -1
+}
+
+func resource(m *migrationv1alpha1.StorageVersionMigration) schema.GroupVersionResource {
+	return schema.GroupVersionResource{
+		Group:    m.Spec.Resource.Group,
+		Version:  m.Spec.Resource.Version,
+		Resource: m.Spec.Resource.Resource,
+	}
+}

--- a/pkg/controller/indexer.go
+++ b/pkg/controller/indexer.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+	"reflect"
+
+	migration_v1alpha1 "github.com/kubernetes-sigs/kube-storage-version-migrator/pkg/apis/migration/v1alpha1"
+	migrationclient "github.com/kubernetes-sigs/kube-storage-version-migrator/pkg/clientset"
+	migrationinformer "github.com/kubernetes-sigs/kube-storage-version-migrator/pkg/informer/migration/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+const (
+	statusIndex     = "Status"
+	statusRunning   = "Running"
+	statusPending   = "Pending"
+	statusCompleted = "Completed"
+)
+
+// migrationStatusIndexFunc categorize StorageVersionMigrations based on their conditions.
+func migrationStatusIndexFunc(obj interface{}) ([]string, error) {
+	m, ok := obj.(*migration_v1alpha1.StorageVersionMigration)
+	if !ok {
+		return []string{}, fmt.Errorf("expected StroageVersionMigration, got %#v", reflect.TypeOf(obj))
+	}
+	if hasCondition(m, migration_v1alpha1.MigrationSucceeded) || hasCondition(m, migration_v1alpha1.MigrationFailed) {
+		return []string{statusCompleted}, nil
+	}
+	if hasCondition(m, migration_v1alpha1.MigrationRunning) {
+		return []string{statusRunning}, nil
+	}
+	return []string{statusPending}, nil
+}
+
+func newStatusIndexedInformer(c migrationclient.Interface) cache.SharedIndexInformer {
+	return migrationinformer.NewStorageVersionMigrationInformer(c, metav1.NamespaceAll, 0, cache.Indexers{statusIndex: migrationStatusIndexFunc})
+}

--- a/pkg/controller/indexer_test.go
+++ b/pkg/controller/indexer_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"reflect"
+	"testing"
+
+	migrationv1alpha1 "github.com/kubernetes-sigs/kube-storage-version-migrator/pkg/apis/migration/v1alpha1"
+	"github.com/kubernetes-sigs/kube-storage-version-migrator/pkg/clientset/fake"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+func newMigration(name string, conditionType migrationv1alpha1.MigrationConditionType) *migrationv1alpha1.StorageVersionMigration {
+	newCondition := migrationv1alpha1.MigrationCondition{
+		Type:   conditionType,
+		Status: corev1.ConditionTrue,
+	}
+	return &migrationv1alpha1.StorageVersionMigration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Status: migrationv1alpha1.StorageVersionMigrationStatus{
+			Conditions: []migrationv1alpha1.MigrationCondition{
+				newCondition,
+			},
+		},
+	}
+}
+
+func TestStatusIndexedInformer(t *testing.T) {
+	running := newMigration("Running", migrationv1alpha1.MigrationRunning)
+	succeeded := newMigration("Succeeded", migrationv1alpha1.MigrationSucceeded)
+	failed := newMigration("Failed", migrationv1alpha1.MigrationFailed)
+	pending := &migrationv1alpha1.StorageVersionMigration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "Pending",
+		},
+	}
+	client := fake.NewSimpleClientset(running, succeeded, failed, pending)
+	informer := newStatusIndexedInformer(client)
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	go informer.Run(stopCh)
+
+	cache.WaitForCacheSync(stopCh, informer.HasSynced)
+	ret, err := informer.GetIndexer().ByIndex(statusIndex, statusRunning)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if e, a := running, ret[0]; !reflect.DeepEqual(e, a) {
+		t.Errorf("expected %v, got %v", e, a)
+	}
+	ret, err = informer.GetIndexer().ByIndex(statusIndex, statusPending)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if e, a := pending, ret[0]; !reflect.DeepEqual(e, a) {
+		t.Errorf("expected %v, got %v", e, a)
+	}
+	ret, err = informer.GetIndexer().ByIndex(statusIndex, statusCompleted)
+	if err != nil {
+		t.Fatal(err)
+	}
+	switch {
+	case reflect.DeepEqual(ret[0], failed) && reflect.DeepEqual(ret[1], succeeded):
+	case reflect.DeepEqual(ret[1], failed) && reflect.DeepEqual(ret[0], succeeded):
+	default:
+		t.Errorf("expected one successful, one failed, got %v", ret)
+	}
+}

--- a/pkg/controller/kubemigrator.go
+++ b/pkg/controller/kubemigrator.go
@@ -1,0 +1,170 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/golang/glog"
+
+	migrationv1alpha1 "github.com/kubernetes-sigs/kube-storage-version-migrator/pkg/apis/migration/v1alpha1"
+	migrationclient "github.com/kubernetes-sigs/kube-storage-version-migrator/pkg/clientset"
+	"github.com/kubernetes-sigs/kube-storage-version-migrator/pkg/migrator"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/tools/cache"
+)
+
+// KubeMigrator monitors storageVersionMigraiton objects, fulfills the
+// migration, and updates the status of the storageVersionMigration objects.
+type KubeMigrator struct {
+	dynamic           dynamic.Interface
+	migrationClient   migrationclient.Interface
+	migrationInformer cache.SharedIndexInformer
+}
+
+// NewKubeMigrator creates KubeMigrator.
+func NewKubeMigrator(dynamic dynamic.Interface, migrationClient migrationclient.Interface) *KubeMigrator {
+	informer := newStatusIndexedInformer(migrationClient)
+	return &KubeMigrator{
+		dynamic:           dynamic,
+		migrationClient:   migrationClient,
+		migrationInformer: informer,
+	}
+}
+
+func (km *KubeMigrator) Run(stopCh <-chan struct{}) {
+	defer utilruntime.HandleCrash()
+	go km.migrationInformer.Run(stopCh)
+	if !cache.WaitForCacheSync(stopCh, km.migrationInformer.HasSynced) {
+		utilruntime.HandleError(fmt.Errorf("Unable to sync caches"))
+		return
+	}
+	wait.Until(km.process, time.Second, stopCh)
+}
+
+func (km *KubeMigrator) process() {
+	// KubeMigrator has only one worker, so it doesn't need to use a
+	// workqueue to ensure only there is a single thread processing a
+	// storageVersionMigration.
+
+	// The already "Running" storageVersionMigrations are the priority.
+	runnings, err := km.migrationInformer.GetIndexer().ByIndex(statusIndex, statusRunning)
+	if err != nil {
+		utilruntime.HandleError(err)
+		return
+	}
+	if len(runnings) != 0 {
+		utilruntime.HandleError(km.processOne(runnings[0]))
+		return
+	}
+
+	// The next priority is the pending storageVersionMigrations.
+	pendings, err := km.migrationInformer.GetIndexer().ByIndex(statusIndex, statusPending)
+	if err != nil {
+		utilruntime.HandleError(err)
+		return
+	}
+	if len(pendings) != 0 {
+		utilruntime.HandleError(km.processOne(pendings[0]))
+		return
+	}
+}
+
+func (km *KubeMigrator) processOne(obj interface{}) error {
+	m, ok := obj.(*migrationv1alpha1.StorageVersionMigration)
+	if !ok {
+		return fmt.Errorf("expected StroageVersionMigration, got %#v", reflect.TypeOf(obj))
+	}
+	// get the fresh object from the apiserver to make sure the object
+	// still exists, and the object is not completed.
+	m, err := km.migrationClient.MigrationV1alpha1().StorageVersionMigrations(m.Namespace).Get(m.Name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	if hasCondition(m, migrationv1alpha1.MigrationSucceeded) || hasCondition(m, migrationv1alpha1.MigrationFailed) {
+		glog.V(2).Infof("The migration has already completed for %#v", m)
+		return nil
+	}
+	m, err = km.updateStatus(m, migrationv1alpha1.MigrationRunning, "")
+	if err != nil {
+		return err
+	}
+	core := migrator.NewMigrator(resource(m), km.dynamic)
+	// If the storageVersionMigration object is deleted during Run(), Run()
+	// will return an error when it tries to write the continueToken into the
+	// migration object. Thus, it's not necessary to register a deletion
+	// event handler with the migrationInformer to interrupt the Run().
+	err = core.Run()
+	utilruntime.HandleError(err)
+	if err == nil {
+		_, err = km.updateStatus(m, migrationv1alpha1.MigrationSucceeded, "")
+		return err
+	}
+	_, err = km.updateStatus(m, migrationv1alpha1.MigrationFailed, err.Error())
+	return err
+}
+
+// updateStatus always retries no matter what kind of error is returned by the
+// apiserver, because it's a pity to start over the entire migration merely
+// because a status update failure.
+// updateStatus also removes other KNOWN conditions.
+func (km *KubeMigrator) updateStatus(m *migrationv1alpha1.StorageVersionMigration, condition migrationv1alpha1.MigrationConditionType, message string) (*migrationv1alpha1.StorageVersionMigration, error) {
+	backoff := wait.Backoff{
+		Steps:    6,
+		Duration: 10 * time.Millisecond,
+		Factor:   5.0,
+		Jitter:   0.1,
+	}
+	return m, wait.ExponentialBackoff(backoff, func() (bool, error) {
+		var newConditions []migrationv1alpha1.MigrationCondition
+		for _, c := range m.Status.Conditions {
+			switch c.Type {
+			case migrationv1alpha1.MigrationRunning:
+			case migrationv1alpha1.MigrationSucceeded:
+			case migrationv1alpha1.MigrationFailed:
+			default:
+				// keeps unknown conditions
+				newConditions = append(newConditions, c)
+			}
+		}
+		newCondition := migrationv1alpha1.MigrationCondition{
+			Type:           condition,
+			Status:         corev1.ConditionTrue,
+			LastUpdateTime: metav1.Now(),
+			Message:        message,
+		}
+		newConditions = append(newConditions, newCondition)
+		m.Status.Conditions = newConditions
+
+		_, err := km.migrationClient.MigrationV1alpha1().StorageVersionMigrations(m.Namespace).UpdateStatus(m)
+		if err == nil {
+			return true, nil
+		}
+		// Always refresh and retry, no matter what kind of error is returned by the apiserver.
+		updated, err := km.migrationClient.MigrationV1alpha1().StorageVersionMigrations(m.Namespace).Get(m.Name, metav1.GetOptions{})
+		if err == nil {
+			m = updated
+		}
+		return false, nil
+	})
+}


### PR DESCRIPTION
Based on #5.

Adding the controller that monitors storageVersionMigration objects and calls pkg/core to migrate resources.

The controller doesn't register event handler with the informer, nor does it use a workqueue, because the controller is single threaded, there is no need to use these tools to make sure only a single thread is working on an object.

The controller just gets an work item (a StorageVersionMigration object) from the informer cache, finishes working on it, updates the status, and then processes the next work item.