### PR TITLE
Properly enable logs in initializer and the migrator

### DIFF
--- a/cmd/initializer/Dockerfile
+++ b/cmd/initializer/Dockerfile
@@ -15,4 +15,4 @@
 FROM alpine:3.6
 
 ADD initializer /initializer
-ENTRYPOINT ["/initializer"]
+ENTRYPOINT ["/initializer", "--alsologtostderr", "--v=2"]

--- a/cmd/initializer/initializer.go
+++ b/cmd/initializer/initializer.go
@@ -1,13 +1,21 @@
 package main
 
 import (
+	goflag "flag"
 	"fmt"
 	"os"
 
+	"github.com/golang/glog"
 	"github.com/kubernetes-sigs/kube-storage-version-migrator/cmd/initializer/app"
+	"github.com/spf13/pflag"
 )
 
 func main() {
+	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
+	pflag.Parse()
+	pflag.VisitAll(func(flag *pflag.Flag) {
+		glog.V(4).Infof("FLAG: --%s=%q", flag.Name, flag.Value)
+	})
 	command := app.NewInitializerCommand()
 	if err := command.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)

--- a/cmd/migrator/Dockerfile
+++ b/cmd/migrator/Dockerfile
@@ -15,4 +15,4 @@
 FROM alpine:3.6
 
 ADD migrator /migrator
-ENTRYPOINT ["/migrator"]
+ENTRYPOINT ["/migrator", "--alsologtostderr", "--v=2"]

--- a/cmd/migrator/migrator.go
+++ b/cmd/migrator/migrator.go
@@ -1,13 +1,21 @@
 package main
 
 import (
+	goflag "flag"
 	"fmt"
 	"os"
 
+	"github.com/golang/glog"
 	"github.com/kubernetes-sigs/kube-storage-version-migrator/cmd/migrator/app"
+	"github.com/spf13/pflag"
 )
 
 func main() {
+	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
+	pflag.Parse()
+	pflag.VisitAll(func(flag *pflag.Flag) {
+		glog.V(4).Infof("FLAG: --%s=%q", flag.Name, flag.Value)
+	})
 	command := app.NewInitializerCommand()
 	if err := command.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)


### PR DESCRIPTION
Otherwise we can't inspect the logs via `kubectl log <pod name>`.

/assign @yliaog