### PR TITLE
Add version to user agent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,13 +31,13 @@ endif
 
 .PHONY: all-containers
 all-containers:
-	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o cmd/initializer/initializer ./cmd/initializer
+	CGO_ENABLED=0 GOOS=linux go build -ldflags "-X github.com/kubernetes-sigs/kube-storage-version-migrator/pkg/version.VERSION=$(VERSION)" -a -installsuffix cgo -o cmd/initializer/initializer ./cmd/initializer
 	docker build --no-cache -t $(REGISTRY)/storage-version-migration-initializer:$(VERSION) cmd/initializer
 	rm cmd/initializer/initializer
-	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o cmd/migrator/migrator ./cmd/migrator
+	CGO_ENABLED=0 GOOS=linux go build -ldflags "-X github.com/kubernetes-sigs/kube-storage-version-migrator/pkg/version.VERSION=$(VERSION)" -a -installsuffix cgo -o cmd/migrator/migrator ./cmd/migrator
 	docker build --no-cache -t $(REGISTRY)/storage-version-migration-migrator:$(VERSION) cmd/migrator
 	rm cmd/migrator/migrator
-	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o cmd/trigger/trigger ./cmd/trigger
+	CGO_ENABLED=0 GOOS=linux go build -ldflags "-X github.com/kubernetes-sigs/kube-storage-version-migrator/pkg/version.VERSION=$(VERSION)" -a -installsuffix cgo -o cmd/trigger/trigger ./cmd/trigger
 	docker build --no-cache -t $(REGISTRY)/storage-version-migration-trigger:$(VERSION) cmd/trigger
 	rm cmd/trigger/trigger
 

--- a/cmd/initializer/app/initializer.go
+++ b/cmd/initializer/app/initializer.go
@@ -6,6 +6,7 @@ import (
 
 	migrationclient "github.com/kubernetes-sigs/kube-storage-version-migrator/pkg/clients/clientset"
 	"github.com/kubernetes-sigs/kube-storage-version-migrator/pkg/initializer"
+	"github.com/kubernetes-sigs/kube-storage-version-migrator/pkg/version"
 	"github.com/spf13/cobra"
 	crdclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/client-go/kubernetes"
@@ -36,7 +37,8 @@ func Run() error {
 	if err != nil {
 		return err
 	}
-	clientset, err := kubernetes.NewForConfig(rest.AddUserAgent(config, initializerUserAgent))
+	config.UserAgent = initializerUserAgent + "/" + version.VERSION
+	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return err
 	}

--- a/cmd/migrator/app/migrator.go
+++ b/cmd/migrator/app/migrator.go
@@ -9,6 +9,7 @@ import (
 
 	migrationclient "github.com/kubernetes-sigs/kube-storage-version-migrator/pkg/clients/clientset"
 	"github.com/kubernetes-sigs/kube-storage-version-migrator/pkg/controller"
+	"github.com/kubernetes-sigs/kube-storage-version-migrator/pkg/version"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -55,7 +56,8 @@ func Run(stopCh <-chan struct{}) error {
 			return err
 		}
 	}
-	dynamic, err := dynamic.NewForConfig(rest.AddUserAgent(config, migratorUserAgent))
+	config.UserAgent = migratorUserAgent + "/" + version.VERSION
+	dynamic, err := dynamic.NewForConfig(config)
 	if err != nil {
 		return err
 	}

--- a/cmd/trigger/app/trigger.go
+++ b/cmd/trigger/app/trigger.go
@@ -8,6 +8,7 @@ import (
 
 	migrationclient "github.com/kubernetes-sigs/kube-storage-version-migrator/pkg/clients/clientset"
 	"github.com/kubernetes-sigs/kube-storage-version-migrator/pkg/trigger"
+	"github.com/kubernetes-sigs/kube-storage-version-migrator/pkg/version"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/rest"
@@ -52,7 +53,8 @@ func Run(stopCh <-chan struct{}) error {
 			return err
 		}
 	}
-	migration, err := migrationclient.NewForConfig(rest.AddUserAgent(config, triggerUserAgent))
+	config.UserAgent = triggerUserAgent + "/" + version.VERSION
+	migration, err := migrationclient.NewForConfig(config)
 	if err != nil {
 		return err
 	}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+var VERSION = "UNKNOWN"

--- a/test/e2e/tests/chaos.go
+++ b/test/e2e/tests/chaos.go
@@ -10,6 +10,7 @@ import (
 
 	migrationv1alpha1 "github.com/kubernetes-sigs/kube-storage-version-migrator/pkg/apis/migration/v1alpha1"
 	migrationclient "github.com/kubernetes-sigs/kube-storage-version-migrator/pkg/clients/clientset"
+	"github.com/kubernetes-sigs/kube-storage-version-migrator/pkg/version"
 	"github.com/kubernetes-sigs/kube-storage-version-migrator/test/e2e/chaosmonkey"
 	"github.com/kubernetes-sigs/kube-storage-version-migrator/test/e2e/util"
 	. "github.com/onsi/ginkgo"
@@ -21,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -83,7 +83,7 @@ func (t *StorageMigratorChaosTest) setupClients() {
 	if err != nil {
 		util.Failf("can't build client config: %v", err)
 	}
-	cfg = rest.AddUserAgent(cfg, "e2e test")
+	cfg.UserAgent = "storage-migration-chaos-test/" + version.VERSION
 	t.migrationClient, err = migrationclient.NewForConfig(cfg)
 	if err != nil {
 		util.Failf("can't build migration client: %v", err)

--- a/test/e2e/tests/crd-migration.go
+++ b/test/e2e/tests/crd-migration.go
@@ -6,6 +6,7 @@ import (
 
 	migrationv1alpha1 "github.com/kubernetes-sigs/kube-storage-version-migrator/pkg/apis/migration/v1alpha1"
 	migrationclient "github.com/kubernetes-sigs/kube-storage-version-migrator/pkg/clients/clientset"
+	"github.com/kubernetes-sigs/kube-storage-version-migrator/pkg/version"
 	"github.com/kubernetes-sigs/kube-storage-version-migrator/test/e2e/util"
 	. "github.com/onsi/ginkgo"
 	corev1 "k8s.io/api/core/v1"
@@ -13,7 +14,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/discovery"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -51,7 +51,8 @@ var _ = Describe("storage version migrator", func() {
 		if err != nil {
 			util.Failf("can't build client config: %v", err)
 		}
-		client, err := migrationclient.NewForConfig(rest.AddUserAgent(cfg, "e2e test"))
+		cfg.UserAgent = "storage-migration-e2e-test/" + version.VERSION
+		client, err := migrationclient.NewForConfig(cfg)
 		if err != nil {
 			util.Failf("can't build client: %v", err)
 		}


### PR DESCRIPTION
Current user-agent is `migrator/v0.0.0 (linux/amd64) kubernetes/$Format/storage-version-migration-migrator`, which isn't particularly useful

cc @caesarxuchao 