### PR TITLE
add release-staging and cloudbuild

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,17 @@
+# See https://cloud.google.com/cloud-build/docs/build-config
+
+timeout: 1200s
+options:
+  substitution_option: ALLOW_LOOSE
+steps:
+  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20190906-745fed4'
+    entrypoint: make
+    env:
+    - DOCKER_CLI_EXPERIMENTAL=enabled
+    - VERSION=$_GIT_TAG
+    - BASE_REF=$_PULL_BASE_REF
+    args:
+    - release-staging
+substitutions:
+  _GIT_TAG: '12345'
+  _PULL_BASE_REF: 'master'


### PR DESCRIPTION
ref https://github.com/kubernetes-sigs/kube-storage-version-migrator/issues/72

v0.0.3 images have been pushed to gcr.io/k8s-staging-storage-migrator with:
```
$ VERSION=v0.0.3 BASE_REF=master make release-staging
```

`cloudbuild.yaml` is a prerequisite for https://github.com/kubernetes/k8s.io/blob/master/k8s.gcr.io/README.md#enabling-automatic-builds. 

/assign @caesarxuchao 