### PR TITLE
udpate permission for storagestate status permission.

### DIFF
--- a/manifests/namespace-rbac.yaml
+++ b/manifests/namespace-rbac.yaml
@@ -9,7 +9,7 @@ metadata:
   name: storage-version-migration-trigger
 rules:
 - apiGroups: ["migration.k8s.io"]
-  resources: ["storagestates"]
+  resources: ["storagestates", "storagestates/status"]
   verbs: ["watch", "get", "list", "delete", "create", "update"]
 - apiGroups: ["migration.k8s.io"]
   resources: ["storageversionmigrations"]


### PR DESCRIPTION
Fix: https://github.com/kubernetes-sigs/kube-storage-version-migrator/issues/87