### PR TITLE
Clarifies that storage migrator always ensures that resources are stored at current storage version

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -28,6 +28,11 @@ The trigger controller
   the API server's [discovery document][] every 10 mins.
 * Creates [migration requests][] for resource types whose storage version changes.
 
+The trigger controller also creates migration requests for all resources when it
+is first installed in a cluster. This means that if the is migrator installed at
+a point where some resources are already stored in etcd at a legacy version, it
+_will_ migrate those resources.
+
 The migration controller processes the migration requests one by one. When migrating
 a resource type, for all objects of that resource type, the migration controller
 gets the object, then writes it back to the API server without modification. The


### PR DESCRIPTION
This small PR updates the user guide to make it clear that this workflow is valid:

1. A user installs a CRD where a stored version is N and creates some CRs
2. They upgrade to a new version where the stored version is N+1
3. At some point later they discover that N will be removed, so they install storage migrator to ensure that any resources get migrated to the _current_ stored version N+1

I thought this could be useful, because initially after reading the user guide I thougt that the storage migrator only creates migration requests when it observes a change so this scenario would not work.






Signed-off-by: irbekrm <irbekrm@gmail.com>